### PR TITLE
feat: Test streams are accessible, disable is_sorted check

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -77,7 +77,7 @@ class HubSpotStream(RESTStream):
         """
         yes_search = not self.config.get("no_search", False)
         return yes_search and self.replication_method == REPLICATION_INCREMENTAL
-    
+
     # Override this property to disable sorting checks, Hubspot API sometimes returns unsorted data. Open issue here:
     # https://community.hubspot.com/t5/APIs-Integrations/Search-API-ascending-sort-does-not-work-descending-does/m-p/922945
     # This is a workaround to avoid the issue, but risks skipping records.

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -77,6 +77,22 @@ class HubSpotStream(RESTStream):
         """
         yes_search = not self.config.get("no_search", False)
         return yes_search and self.replication_method == REPLICATION_INCREMENTAL
+    
+    # Override this property to disable sorting checks, Hubspot API sometimes returns unsorted data. Open issue here:
+    # https://community.hubspot.com/t5/APIs-Integrations/Search-API-ascending-sort-does-not-work-descending-does/m-p/922945
+    # This is a workaround to avoid the issue, but risks skipping records.
+    # This solution is implemented in the original tap-hubspot repo here: https://github.com/YouCruit/tap-hubspot/pull/24
+    @property
+    def check_sorted(self) -> bool:
+        """Check if stream is sorted.
+
+        This setting enables additional checks which may trigger
+        `InvalidStreamSortException` if records are found which are unsorted.
+
+        Returns:
+            `True` if sorting is checked. Defaults to `True`.
+        """
+        return False
 
     @property
     def authenticator(self) -> BearerTokenAuthenticator:


### PR DESCRIPTION
We test to see if streams are accessible with API scopes, skipping those that are not. Throws an error if no streams are accessible.

We also skip the is_sorted check as done here in the original repo: https://github.com/YouCruit/tap-hubspot/pull/24/files
It's to account for this issue with Hubspot API: https://community.hubspot.com/t5/APIs-Integrations/Search-API-ascending-sort-does-not-work-descending-does/m-p/922945