### PR TITLE
chore: add replication key back to companies stream

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -262,6 +262,7 @@ class HubSpotStream(RESTStream):
                     ]
                 }
             ]
+        self.logger.info(f"Request Payload: {body}")
         return body
 
     def get_appropriate_replication_key_value(

--- a/tap_hubspot/streams/companies.py
+++ b/tap_hubspot/streams/companies.py
@@ -67,8 +67,7 @@ class CompaniesStream(HubSpotStream):
 
     @property
     def replication_key(self) -> Optional[str]:
-        return None
-        # return None if self.config.get("no_search", False) else "hs_lastmodifieddate"
+        return None if self.config.get("no_search", False) else "hs_lastmodifieddate"
 
     @replication_key.setter
     def replication_key(self, _):


### PR DESCRIPTION
Because we skip is_sorted check we can add replication key back in.