### PR TITLE
fix: remove explicitly set extra properties in contacts

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -262,7 +262,7 @@ class HubSpotStream(RESTStream):
                     ]
                 }
             ]
-        self.logger.info(f"Request Payload: {body}")
+        # self.logger.info(f"Request Payload: {body}")
         return body
 
     def get_appropriate_replication_key_value(

--- a/tap_hubspot/streams/contacts.py
+++ b/tap_hubspot/streams/contacts.py
@@ -47,25 +47,6 @@ class ContactsStream(HubSpotStream):
             ),
         )
 
-        # Needs to be defined manually since 2023-07-12 when
-        # the list of properties in hubspot became to long for a request.
-        # Error: 414 Client Error: URI Too Long for path
-        self.extra_properties = [
-            "email",
-            "firstname",
-            "lastname",
-            "jobtitle",
-            "call_center_candidate_id",
-            "candidate_id",
-            "interested_in_lanefinder_driver_force",
-            "hs_last_sales_activity_timestamp",
-            "hs_lead_status",
-            "hs_searchable_calculated_international_mobile_number",
-            "hubspot_owner_id",
-            "hs_calculated_phone_number",
-            "hs_timezone",
-        ]
-
         if self.replication_key:
             props.append(
                 th.Property(


### PR DESCRIPTION
We have to be careful merging in changes from the original repo, they are hardcoding stuff in there that is not applicable to all hubspot accounts.