### PR TITLE
Add meetings associations to company and contact streams

### DIFF
--- a/tap_hubspot/streams/company_associations.py
+++ b/tap_hubspot/streams/company_associations.py
@@ -17,7 +17,7 @@ class CompanyAssociationsStream(HubSpotStream):
     name = "company_associations"
     path = (
         # "/crm/v4/objects/company/{id}/?associations=contacts,deals"
-        "/crm/v4/objects/company/?associations=contacts,deals"
+        "/crm/v4/objects/company/?associations=contacts,deals,meetings"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "companies"

--- a/tap_hubspot/streams/contact_associations.py
+++ b/tap_hubspot/streams/contact_associations.py
@@ -18,7 +18,7 @@ class ContactAssociationsStream(HubSpotStream):
     name = "contact_associations"
     path = (
         # "/crm/v4/objects/contact/{id}/?associations=companies,deals"
-        "/crm/v4/objects/contact/?associations=companies,deals"
+        "/crm/v4/objects/contact/?associations=companies,deals,meetings"
         "&propertiesWithHistory=hubspot_owner_id"
     )
     properties_object_type = "contacts"


### PR DESCRIPTION
This PR adds meetings associations to both company and contact association streams, allowing the tap to extract meeting associations alongside existing contact and deal associations.