### PR TITLE
fix: Only get default properties for archived companies

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -1,5 +1,4 @@
 """REST client handling, including HubSpotStream base class."""
-import re
 import gzip
 import json
 import logging
@@ -189,10 +188,6 @@ class HubSpotStream(RESTStream):
         }
         props_to_get = self.get_properties()
         if props_to_get:
-            # filter out properties like hs_date_entered_121383958, hs_date_exited_25023851
-            props_to_get = [
-                s for s in props_to_get if not re.search(r".*_[0-9]{4,}$", s)
-            ]
             params["properties"] = props_to_get
         if next_page_token:
             params["after"] = next_page_token

--- a/tap_hubspot/streams/archived_companies.py
+++ b/tap_hubspot/streams/archived_companies.py
@@ -16,8 +16,12 @@ class ArchivedCompaniesStream(HubSpotStream):
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        params = super().get_url_params(context, next_page_token)
-        params["archived"] = True
+        params = {
+            "archived": True,
+            "limit": 100,
+        }
+        if next_page_token:
+            params["after"] = next_page_token
         return params
 
     @property
@@ -72,7 +76,7 @@ class ArchivedCompaniesStream(HubSpotStream):
 
     @property
     def replication_key(self) -> Optional[str]:
-        # for full table replication, we don't need a replication key
+        # incremental replication is not supported for archived companies
         return None
 
     @replication_key.setter


### PR DESCRIPTION
Hubspot API is more restrictive on the number of fields we get back when pulling archived companies `414 Client Error: URI Too Long for path: /crm/v3/objects/companies`

We only need to get the archived company ids and when they were archived.